### PR TITLE
*fix vsync linux error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,15 @@ const BACK_COLOR: Color = [0.204, 0.286, 0.369, 1.0];
 fn main() {
     let (width, height) = (20, 20);
 
+    // Prepare window settings
+    let mut window_settings = WindowSettings::new("Rust Snake",
+    [to_gui_coord_u32(width), to_gui_coord_u32(height)]).exit_on_esc(true);
+
+    // Fix vsync extension error for linux
+    window_settings.set_vsync(true); 
+
     // Create a window
-    let mut window: PistonWindow = WindowSettings::new("Rust Snake",
-        [to_gui_coord_u32(width), to_gui_coord_u32(height)]).exit_on_esc(true).build().unwrap();
+    let mut window: PistonWindow = window_settings.build().unwrap();
 
     // Create a snake
     let mut game = Game::new(width, height);


### PR DESCRIPTION
**Error fixed:**

cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/rust-snake`
libEGL warning: DRI2: failed to authenticate
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CreationErrors([NoAvailablePixelFormat, OsError("Couldn't find any available vsync extension")])', src/main.rs:21:88
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


**Linux distro info:**

DISTRIB_ID=ManjaroLinux
DISTRIB_RELEASE=21.2.0
DISTRIB_CODENAME=Qonos
DISTRIB_DESCRIPTION="Manjaro Linux"